### PR TITLE
factoid: Fix out-of-range index

### DIFF
--- a/pkg/gomr/factoid.go
+++ b/pkg/gomr/factoid.go
@@ -60,7 +60,7 @@ func (fp FactoidPlugin) Parse(sender, channel, input string, conn *Connection) (
 				for i := range factoids {
 					conn.SendTo(channel, "#"+strconv.Itoa(i+1)+" "+fact+": "+factoids[i].Definition)
 				}
-			} else {
+			} else if len(factoids) > 0 {
 				conn.SendTo(channel, fact+" is "+factoids[0].Definition)
 			}
 


### PR DESCRIPTION
Avoid crashing on an out-of-range index if a factoid lookup returns 0 results.